### PR TITLE
Record and retry failed PO line items

### DIFF
--- a/egrn_service/admin.py
+++ b/egrn_service/admin.py
@@ -35,6 +35,8 @@ def _get_latest_unit_price(product_id):
 
 
 class PurchaseOrderAdmin(ModelAdmin):
+	list_display = ['po_id', 'vendor', 'date', 'failed_line_items_count']
+	actions = ['retry_failed_line_items']
 	# Search fields: vendor, object_id, po_id
 	search_fields = [
 		'vendor__user__first_name',
@@ -51,6 +53,38 @@ class PurchaseOrderAdmin(ModelAdmin):
         'line_items__delivery_store__byd_cost_center_code',
 		
 	]
+
+	def failed_line_items_count(self, obj):
+		return len(obj.failed_line_items or [])
+	failed_line_items_count.short_description = 'Failed Line Items'
+
+	@admin.action(description='Retry failed line items')
+	def retry_failed_line_items(self, request, queryset):
+		total_recovered = 0
+		total_remaining = 0
+		for purchase_order in queryset:
+			result = purchase_order.retry_failed_line_items()
+			total_recovered += result['recovered']
+			total_remaining += result['remaining']
+
+		if total_recovered:
+			self.message_user(
+				request,
+				f"Recovered {total_recovered} line item(s).",
+				level=messages.SUCCESS,
+			)
+		if total_remaining:
+			self.message_user(
+				request,
+				f"{total_remaining} line item(s) still failing.",
+				level=messages.WARNING,
+			)
+		if not total_recovered and not total_remaining:
+			self.message_user(
+				request,
+				"No failed line items to retry.",
+				level=messages.INFO,
+			)
 
 
 class PurchaseOrderLineItemAdmin(ModelAdmin):

--- a/egrn_service/migrations/0023_purchaseorder_failed_line_items.py
+++ b/egrn_service/migrations/0023_purchaseorder_failed_line_items.py
@@ -1,0 +1,18 @@
+# Generated for failed line item tracking on PurchaseOrder.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('egrn_service', '0022_stockconsumptionrecord_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='purchaseorder',
+            name='failed_line_items',
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/egrn_service/models.py
+++ b/egrn_service/models.py
@@ -102,6 +102,9 @@ class PurchaseOrder(models.Model):
 	total_net_amount = models.DecimalField(max_digits=15, decimal_places=3, blank=False, null=False)
 	date = models.DateField()
 	metadata = models.JSONField(default=dict)
+	# Raw ByD line items that could not be created (e.g. unresolved store). Each
+	# entry retains the original ByD payload so the item can be retried later.
+	failed_line_items = models.JSONField(default=list, blank=True)
 	
 	delivery_status_code = [('1', 'Not Delivered'), ('2', 'Partially Delivered'), ('3', 'Completely Delivered')]
 	
@@ -137,34 +140,107 @@ class PurchaseOrder(models.Model):
 		self.date = to_python_time(po["LastChangeDateTime"])
 		po_items = po.pop("Item")
 		self.metadata = po
+		self.failed_line_items = []
 		self.save()
 		
+		if not po_items:
+			self.delete()
+			raise Exception("No line items were found for purchase order.")
+		
 		created = 0
-		try:
-			for line_item in po_items:
-				self.__create_line_items__(line_item)
+		for line_item in po_items:
+			success, error = self.__create_line_items__(line_item)
+			if success:
 				created += 1
-		except Exception as e:
-			self.delete()
-			raise Exception(f"Error creating line items for purchase order: {e}")
-		if created == 0:
-			self.delete()
-			raise Exception("No line items were created for purchase order.")
+			else:
+				# Keep the raw payload so the item can be retried later instead of
+				# silently dropping it.
+				self.__record_failed_line_item__(line_item, error)
+				logging.warning(
+					f"PO {self.po_id}: could not create line item "
+					f"{line_item.get('ObjectID')} - {error}"
+				)
+		
+		self.save(update_fields=['failed_line_items'])
 		return self
 	
 	def __create_line_items__(self, line_item):
-		po_line_item = PurchaseOrderLineItem()
+		'''
+			Attempts to create a single line item from its raw ByD payload.
+			Returns a (success, error) tuple: (True, None) on success or
+			(False, <reason>) when the item could not be created.
+		'''
+		try:
+			po_line_item = PurchaseOrderLineItem()
+			
+			po_line_item.purchase_order = self
+			po_line_item.object_id = line_item["ObjectID"]
+			po_line_item.product_name = line_item["Description"]
+			po_line_item.product_id = line_item["ProductID"]
+			po_line_item.quantity = float(line_item["Quantity"])
+			po_line_item.unit_price = line_item["ListUnitPriceAmount"]
+			po_line_item.unit_of_measurement = line_item["QuantityUnitCodeText"]
+			po_line_item.metadata = line_item
+			
+			# `save` returns False (without persisting) when the delivery store
+			# cannot be resolved.
+			if po_line_item.save() is False:
+				location_id = (line_item.get("ItemShipToLocation") or {}).get("LocationID")
+				return False, f"Delivery store not found for cost center '{location_id}'."
+			return True, None
+		except Exception as e:
+			return False, str(e)
+	
+	def __build_failed_entry__(self, line_item, error):
+		return {
+			"object_id": line_item.get("ObjectID"),
+			"product_id": line_item.get("ProductID"),
+			"product_name": line_item.get("Description"),
+			"error": str(error),
+			"last_attempt": timezone.now().isoformat(),
+			"data": line_item,
+		}
+	
+	def __record_failed_line_item__(self, line_item, error):
+		'''
+			Records (or refreshes) a failed line item entry, keyed by ByD ObjectID.
+		'''
+		object_id = line_item.get("ObjectID")
+		self.failed_line_items = [
+			entry for entry in (self.failed_line_items or [])
+			if entry.get("object_id") != object_id
+		]
+		self.failed_line_items.append(self.__build_failed_entry__(line_item, error))
+	
+	def retry_failed_line_items(self):
+		'''
+			Re-attempts creation of any previously failed line items. Items that
+			succeed are removed from `failed_line_items`; those that still fail are
+			kept with an updated error and timestamp. Returns a summary dict.
+		'''
+		pending = self.failed_line_items or []
+		if not pending:
+			return {"recovered": 0, "remaining": 0}
 		
-		po_line_item.purchase_order = self
-		po_line_item.object_id = line_item["ObjectID"]
-		po_line_item.product_name = line_item["Description"]
-		po_line_item.product_id = line_item["ProductID"]
-		po_line_item.quantity = float(line_item["Quantity"])
-		po_line_item.unit_price = line_item["ListUnitPriceAmount"]
-		po_line_item.unit_of_measurement = line_item["QuantityUnitCodeText"]
-		po_line_item.metadata = line_item
+		existing_object_ids = set(self.line_items.values_list('object_id', flat=True))
+		still_failed = []
+		recovered = 0
+		for entry in pending:
+			line_item = entry.get("data") or {}
+			object_id = line_item.get("ObjectID") or entry.get("object_id")
+			# Already created in a previous attempt; just drop the stale record.
+			if object_id in existing_object_ids:
+				recovered += 1
+				continue
+			success, error = self.__create_line_items__(line_item)
+			if success:
+				recovered += 1
+			else:
+				still_failed.append(self.__build_failed_entry__(line_item, error))
 		
-		po_line_item.save()
+		self.failed_line_items = still_failed
+		self.save(update_fields=['failed_line_items'])
+		return {"recovered": recovered, "remaining": len(still_failed)}
 	
 	def __str__(self):
 		return f"PO-{self.po_id}"
@@ -332,6 +408,11 @@ class GoodsReceivedNote(models.Model):
 			self.purchase_order = new_po.create_purchase_order(po_data)
 		except Exception as e:
 			raise e
+		
+		# Recreate any line items that previously failed so the GRN can be matched
+		# against them (e.g. a delivery store that now exists).
+		if self.purchase_order.failed_line_items:
+			self.purchase_order.retry_failed_line_items()
 		
 		# Create the GRN Number by appending a number to the end of the PO ID
 		self.grn_number = int(str(po_id) + '1')

--- a/egrn_service/views.py
+++ b/egrn_service/views.py
@@ -144,6 +144,10 @@ def get_purchase_order(request, po_id):
 					f"Order with ID {po_id} not found or is not in a valid state for processing.",
 					status.HTTP_404_NOT_FOUND
 				)
+		# Recreate any line items that previously failed (e.g. a store that did
+		# not exist when the PO was first fetched but is now available).
+		if orders.failed_line_items:
+			orders.retry_failed_line_items()
 		# Serialize the PurchaseOrder object
 		serializer = PurchaseOrderSerializer(orders).data
 		serializer["Item"] = list(


### PR DESCRIPTION
Persist line items that fail to create from ByD (e.g. unresolved store) on PurchaseOrder.failed_line_items instead of silently dropping them. Retry recreation automatically when a PO is called up and via a new admin 'Retry failed line items' action with a failed-count column.