### PR TITLE
Feature/multi approval

### DIFF
--- a/approval_service/urls.py
+++ b/approval_service/urls.py
@@ -12,7 +12,8 @@ from approval_service.views import (
 
 urlpatterns = [
 	# Sign
-    path('sign/<str:target_class>/<int:object_id>', sign_signable_view),
+    # path('sign/<str:target_class>/<int:object_id>', sign_signable_view),
+    path('sign/<str:target_class>', sign_signable_view),
 	# Get signables for a specific user's role.
     path('get/<str:target_class>/<str:status_filter>', get_user_signable_view),
 	# Get signables for a specific user's role.

--- a/approval_service/views.py
+++ b/approval_service/views.py
@@ -209,8 +209,9 @@ class KeystoreAPIView(APIView):
 @authentication_classes([AdfsAccessTokenAuthentication])
 def sign_signable_view(request, target_class):
 	"""
-	Optimized signing with caching and bulk operations.
-	Supports signing multiple objects in a single request.
+	Bulk signing.
+	accounts_payable is restricted to single-item signing with a mandatory comment;
+	all other roles may sign multiple objects in one request.
 	"""
 	
 	target = get_signable_class(target_class)
@@ -224,7 +225,6 @@ def sign_signable_view(request, target_class):
 	signable_class = target.get("class")
 	signable_app_label = target.get("app_label")
 	
-	# Check permissions (cached)
 	permission_key = f"user_permission_{request.user.id}_{signable_app_label}_can_sign_signable"
 	has_permission = get_or_set_cache(
 		permission_key,
@@ -238,15 +238,34 @@ def sign_signable_view(request, target_class):
 			status=status.HTTP_403_FORBIDDEN
 		)
 	
-	# Accept either a single object_id or a list of object_ids
 	object_ids = request.data.get("object_ids")
 	if not object_ids:
-		return APIResponse(
-			"No object_ids provided.",
-			status=status.HTTP_400_BAD_REQUEST
-		)
+		return APIResponse("No object_ids provided.", status=status.HTTP_400_BAD_REQUEST)
 	if not isinstance(object_ids, list):
 		object_ids = [object_ids]
+	
+	# Use the existing helper to determine which workflow roles this user holds
+	approval_utilities = ApprovalUtilities(target)
+	user_roles = approval_utilities.get_relevant_permissions(request.user)
+	
+	RESTRICTED_ROLE = "accounts_payable"
+	is_accounts_payable = RESTRICTED_ROLE in user_roles
+	
+	# accounts_payable cannot multi-select
+	if is_accounts_payable and len(object_ids) > 1:
+		return APIResponse(
+			"accounts_payable cannot sign multiple invoices at once. Please sign one at a time.",
+			status=status.HTTP_400_BAD_REQUEST
+		)
+	
+	# accounts_payable must always provide a comment
+	if is_accounts_payable:
+		comment = (request.data.get('comment') or '').strip()
+		if not comment:
+			return APIResponse(
+				"A comment is required for accounts_payable approval.",
+				status=status.HTTP_400_BAD_REQUEST
+			)
 	
 	signed = []
 	failed = {}
@@ -268,7 +287,6 @@ def sign_signable_view(request, target_class):
 		except Exception as e:
 			failed[object_id] = f"Internal Error: {e}"
 	
-	# Invalidate related caches once, after processing the batch
 	if signed:
 		invalidate_user_cache(request.user.id, "signables")
 		CacheManager.invalidate_pattern(f"*{target_class}*")
@@ -279,7 +297,6 @@ def sign_signable_view(request, target_class):
 		return APIResponse(message="Partially successful.", status=status.HTTP_207_MULTI_STATUS, data={"signed": signed, "failed": failed})
 	else:
 		return APIResponse(message="Failed to sign objects.", status=status.HTTP_400_BAD_REQUEST, data={"failed": failed})
-
 		
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])

--- a/approval_service/views.py
+++ b/approval_service/views.py
@@ -135,15 +135,84 @@ class KeystoreAPIView(APIView):
 		return APIResponse("Keystore created.", status=status.HTTP_201_CREATED)
 
 
+# @api_view(['POST'])
+# @permission_classes([IsAuthenticated])
+# @authentication_classes([AdfsAccessTokenAuthentication])
+# def sign_signable_view(request, target_class, object_id):
+# 	"""
+# 	Optimized signing with caching and bulk operations.
+# 	"""
+	
+# 	# Cache target class lookup
+# 	target = get_signable_class(target_class)
+	
+# 	if not target:
+# 		return APIResponse(
+# 			f"A signable object of type {target_class} was not found.", 
+# 			status=status.HTTP_404_NOT_FOUND
+# 		)
+	
+# 	signable_class = target.get("class")
+# 	signable_app_label = target.get("app_label")
+	
+# 	# Check permissions (cached)
+# 	permission_key = f"user_permission_{request.user.id}_{signable_app_label}_can_sign_signable"
+# 	has_permission = get_or_set_cache(
+# 		permission_key,
+# 		lambda: request.user.has_perm(f"{signable_app_label}.can_sign_signable"),
+# 		CacheManager.TIMEOUT_MEDIUM
+# 	)
+	
+# 	if not has_permission:
+# 		return APIResponse(
+# 			f"You do not have permission to sign this {signable_class} object.", 
+# 			status=status.HTTP_403_FORBIDDEN
+# 		)
+	
+# 	# Get signable object with optimized query
+# 	try:
+# 		signable = signable_class.objects.select_related().get(id=object_id)
+# 	except ObjectDoesNotExist:
+# 		return APIResponse(
+# 			f"No {target_class} found with ID {object_id}.", 
+# 			status=status.HTTP_404_NOT_FOUND
+# 		)
+	
+# 	try:
+# 		# Sign the object
+# 		signable.sign(request)
+		
+# 		# Invalidate related caches
+# 		invalidate_user_cache(request.user.id, "signables")
+# 		CacheManager.invalidate_pattern(f"*{target_class}*")
+		
+# 	except PermissionError:
+# 		return APIResponse(
+# 			f"You do not have permission to sign this {target_class} object.", 
+# 			status=status.HTTP_403_FORBIDDEN
+# 		)
+# 	except ValidationError as ve:
+# 		return APIResponse(
+# 			f"Unable to sign this {target_class} object: {ve}", 
+# 			status=status.HTTP_400_BAD_REQUEST
+# 		)
+# 	except Exception as e:
+# 		return APIResponse(
+# 			f"Internal Error: {e}", 
+# 			status=status.HTTP_500_INTERNAL_SERVER_ERROR
+# 		)
+	
+# 	return APIResponse(message="Successful.", status=status.HTTP_200_OK)
+
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 @authentication_classes([AdfsAccessTokenAuthentication])
-def sign_signable_view(request, target_class, object_id):
+def sign_signable_view(request, target_class):
 	"""
 	Optimized signing with caching and bulk operations.
+	Supports signing multiple objects in a single request.
 	"""
 	
-	# Cache target class lookup
 	target = get_signable_class(target_class)
 	
 	if not target:
@@ -169,42 +238,49 @@ def sign_signable_view(request, target_class, object_id):
 			status=status.HTTP_403_FORBIDDEN
 		)
 	
-	# Get signable object with optimized query
-	try:
-		signable = signable_class.objects.select_related().get(id=object_id)
-	except ObjectDoesNotExist:
+	# Accept either a single object_id or a list of object_ids
+	object_ids = request.data.get("object_ids")
+	if not object_ids:
 		return APIResponse(
-			f"No {target_class} found with ID {object_id}.", 
-			status=status.HTTP_404_NOT_FOUND
-		)
-	
-	try:
-		# Sign the object
-		signable.sign(request)
-		
-		# Invalidate related caches
-		invalidate_user_cache(request.user.id, "signables")
-		CacheManager.invalidate_pattern(f"*{target_class}*")
-		
-	except PermissionError:
-		return APIResponse(
-			f"You do not have permission to sign this {target_class} object.", 
-			status=status.HTTP_403_FORBIDDEN
-		)
-	except ValidationError as ve:
-		return APIResponse(
-			f"Unable to sign this {target_class} object: {ve}", 
+			"No object_ids provided.",
 			status=status.HTTP_400_BAD_REQUEST
 		)
-	except Exception as e:
-		return APIResponse(
-			f"Internal Error: {e}", 
-			status=status.HTTP_500_INTERNAL_SERVER_ERROR
-		)
+	if not isinstance(object_ids, list):
+		object_ids = [object_ids]
 	
-	return APIResponse(message="Successful.", status=status.HTTP_200_OK)
+	signed = []
+	failed = {}
+	
+	for object_id in object_ids:
+		try:
+			signable = signable_class.objects.select_related().get(id=object_id)
+		except ObjectDoesNotExist:
+			failed[object_id] = f"No {target_class} found with ID {object_id}."
+			continue
+		
+		try:
+			signable.sign(request)
+			signed.append(object_id)
+		except PermissionError:
+			failed[object_id] = f"You do not have permission to sign this {target_class} object."
+		except ValidationError as ve:
+			failed[object_id] = f"Unable to sign this {target_class} object: {ve}"
+		except Exception as e:
+			failed[object_id] = f"Internal Error: {e}"
+	
+	# Invalidate related caches once, after processing the batch
+	if signed:
+		invalidate_user_cache(request.user.id, "signables")
+		CacheManager.invalidate_pattern(f"*{target_class}*")
+	
+	if signed and not failed:
+		return APIResponse(message="Successful.", status=status.HTTP_200_OK, data={"signed": signed})
+	elif signed and failed:
+		return APIResponse(message="Partially successful.", status=status.HTTP_207_MULTI_STATUS, data={"signed": signed, "failed": failed})
+	else:
+		return APIResponse(message="Failed to sign objects.", status=status.HTTP_400_BAD_REQUEST, data={"failed": failed})
 
-
+		
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @authentication_classes([AdfsAccessTokenAuthentication])


### PR DESCRIPTION
Multi-select approval for signable objects

What this changes:

Refactored sign_signable_view to accept a list of object_ids in the request body instead of a single object_id in the URL path
Updated the corresponding route in approval_service/urls.py accordingly
Preserves the existing behavior for single-item signing (a single-element list still works)

Business rules enforced:

accounts_payable role is restricted to single-item signing only (multi-select rejected with 400)
accounts_payable role must always supply a comment (400 if missing or blank)
All other roles (line_manager, internal_control, head_of_finance, snr_manager_finance, dmd_ss, md) may sign multiple objects in one request